### PR TITLE
Place the MQTT Loop in a try/except block

### DIFF
--- a/adafruit_funhouse/network.py
+++ b/adafruit_funhouse/network.py
@@ -108,7 +108,8 @@ class Network(NetworkBase):
     def mqtt_loop(self):
         """Run the MQTT Loop"""
         try:
-            self._mqtt_client.loop
+            if self._mqtt_client is not None:
+                self._mqtt_client.loop()
         except MQTT.MMQTTException:
             pass
 

--- a/adafruit_funhouse/network.py
+++ b/adafruit_funhouse/network.py
@@ -65,7 +65,6 @@ class Network(NetworkBase):
         )
         self._mqtt_client = None
         self.mqtt_connect = None
-        self.mqtt_loop = None
         self.mqtt_publish = None
 
     def init_io_mqtt(self):
@@ -95,7 +94,6 @@ class Network(NetworkBase):
         if use_io:
             self._mqtt_client = IO_MQTT(self._mqtt_client)
         self.mqtt_connect = self._mqtt_client.connect
-        self.mqtt_loop = self._mqtt_client.loop
         self.mqtt_publish = self._mqtt_client.publish
 
         return self._mqtt_client
@@ -106,6 +104,13 @@ class Network(NetworkBase):
         if self._mqtt_client is not None:
             return self._mqtt_client
         raise RuntimeError("Please initialize MQTT before using")
+
+    def mqtt_loop(self):
+        """Run the MQTT Loop"""
+        try:
+            self._mqtt_client.loop
+        except MQTT.MMQTTException:
+            pass
 
     @property
     def on_mqtt_connect(self):

--- a/adafruit_funhouse/network.py
+++ b/adafruit_funhouse/network.py
@@ -110,8 +110,8 @@ class Network(NetworkBase):
         try:
             if self._mqtt_client is not None:
                 self._mqtt_client.loop()
-        except MQTT.MMQTTException:
-            pass
+        except MQTT.MMQTTException as err:
+            print("MMQTTException: {0}".format(err))
 
     @property
     def on_mqtt_connect(self):


### PR DESCRIPTION
This is to solve an issue that both @jedgarpark and I ran into when running this overnight:
```
Traceback (most recent call last):
  File "code.py", line 65, in <module>
  File "adafruit_io/adafruit_io.py", line 215, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 782, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 552, in ping
MMQTTException: PINGRESP not returned from broker.
```