### PR TITLE
Use SSL by default for MQTT

### DIFF
--- a/adafruit_funhouse/network.py
+++ b/adafruit_funhouse/network.py
@@ -77,10 +77,19 @@ class Network(NetworkBase):
                 "Adafruit IO secrets are kept in secrets.py, please add them there!\n\n"
             ) from KeyError
 
-        return self.init_mqtt(IO_MQTT_BROKER, 1883, aio_username, aio_key, True)
+        return self.init_mqtt(
+            IO_MQTT_BROKER, MQTT.MQTT_TLS_PORT, aio_username, aio_key, True
+        )
 
     # pylint: disable=too-many-arguments
-    def init_mqtt(self, broker, port=1883, username=None, password=None, use_io=False):
+    def init_mqtt(
+        self,
+        broker,
+        port=MQTT.MQTT_TLS_PORT,
+        username=None,
+        password=None,
+        use_io=False,
+    ):
         """Initialize MQTT"""
         self.connect()
         self._mqtt_client = MQTT.MQTT(

--- a/adafruit_funhouse/network.py
+++ b/adafruit_funhouse/network.py
@@ -77,15 +77,13 @@ class Network(NetworkBase):
                 "Adafruit IO secrets are kept in secrets.py, please add them there!\n\n"
             ) from KeyError
 
-        return self.init_mqtt(
-            IO_MQTT_BROKER, MQTT.MQTT_TLS_PORT, aio_username, aio_key, True
-        )
+        return self.init_mqtt(IO_MQTT_BROKER, 8883, aio_username, aio_key, True)
 
     # pylint: disable=too-many-arguments
     def init_mqtt(
         self,
         broker,
-        port=MQTT.MQTT_TLS_PORT,
+        port=8883,
         username=None,
         password=None,
         use_io=False,


### PR DESCRIPTION
Fixes #4. It looks like I was already setting it up correctly to use SSL, but just needed to use the TLS port (8883) by default.