### PR TITLE
Update slider cap_map

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -179,7 +179,7 @@ class Peripherals:
         Return the slider position value in the range of 0.0-1.0 or None if not touched
         """
         val = 0
-        cap_map = b"\x01\x03\x02\x05\x04\x0c\x08\x18\x10"
+        cap_map = b"\x01\x03\x02\x06\x04\x0c\x08\x18\x10"
         for cap in range(5):
             if self._ctp[cap + 3].value:
                 val += 1 << (cap)


### PR DESCRIPTION
Ref: https://forums.adafruit.com/viewtopic.php?f=59&t=179496#p874102

RufusVS2020 said:
> (change 0x05 to 0x06)
The code is designed to track when you are pressing a single contact or two adjacent contacts. If you take the binary of
the values, you should have a single bit or two adjacent bits. The binary for 0x05 is 0b00101 which clearly does not have
the required adjacent bits. 0x06 is 0b00110 which is the correct pattern.

I don't have a FunHouse to test with but this has been reported working on the AdaFruit Forums and the issue was just reappeared on Discord.