### PR TITLE
Update slider

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -179,15 +179,11 @@ class Peripherals:
         Return the slider position value in the range of 0.0-1.0 or None if not touched
         """
         val = 0
-        cap_map = b"\x01\x03\x02\x06\x04\x0c\x08\x18\x10"
+        cap_map = (0x01, 0x03, 0x02, 0x06, 0x04, 0x0c, 0x08, 0x18, 0x10)
         for cap in range(5):
             if self._ctp[cap + 3].value:
                 val += 1 << (cap)
-        for i, pos in enumerate(tuple(cap_map)):
-            if val == pos:
-                print(i, len(cap_map) - 1)
-                return round(i / (len(cap_map) - 1), 1)
-        return None
+        return cap_map.index(val) / 8 if val in cap_map else None
 
     @property
     def light(self):

--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -179,7 +179,7 @@ class Peripherals:
         Return the slider position value in the range of 0.0-1.0 or None if not touched
         """
         val = 0
-        cap_map = (0x01, 0x03, 0x02, 0x06, 0x04, 0x0c, 0x08, 0x18, 0x10)
+        cap_map = (0x01, 0x03, 0x02, 0x06, 0x04, 0x0C, 0x08, 0x18, 0x10)
         for cap in range(5):
             if self._ctp[cap + 3].value:
                 val += 1 << (cap)


### PR DESCRIPTION
Removes a left over serial print, but also changes the actual slider logic. With rounding to first decimal place there was a jump from 0.2 to 0.4 and 0.6 to 0.8. The slider has 9 possible "positions", which leads to increments of 1/8th:
```
1 0.000
2 0.125
3 0.250
4 0.375
5 0.500
6 0.625
7 0.750
8 0.875
9 1.000
```
So, instead of rounding, return the slider value with 1/8th increments.

Test code:
```python
import time
from adafruit_funhouse import FunHouse

fh = FunHouse()

while True:
    s = fh.peripherals.slider
    if s is not None:
        print(s)
        time.sleep(0.1)
```

Output:
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit FunHome with ESP32S2
>>> import test_slider
1.0
1.0
1.0
0.875
0.75
0.625
0.625
0.625
0.5
0.5
0.375
0.375
0.375
0.25
0.25
0.25
0.125
0.125
0.125
0.125
0.0
0.0
0.0
```