### PR TITLE
allow tone frequency of zero

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -96,8 +96,8 @@ class Peripherals:
         It will attempt to play the sound up to 3 times in the case of
         an error.
         """
-        if frequency <= 0:
-            raise ValueError("The frequency has to be greater than 0.")
+        if frequency < 0:
+            raise ValueError("Negative frequencies are not allowed.")
         attempt = 0
         # Try up to 3 times to play the sound
         while attempt < 3:


### PR DESCRIPTION
This corresponds to the issue request I placed, then decided I could make a pull request (though I'm new to the process).
This fix allows a frequency of zero specified to the play_tone function.
Issue Request: [https://github.com/adafruit/Adafruit_CircuitPython_FunHouse/issues/20](url)