### PR TITLE
Update the import of adafruit_dps310 to latest

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -32,7 +32,7 @@ from digitalio import DigitalInOut, Direction, Pull
 from analogio import AnalogIn
 import touchio
 import simpleio
-import adafruit_dps310
+import adafruit_dps310.advanced
 import adafruit_ahtx0
 import adafruit_dotstar
 
@@ -83,7 +83,7 @@ class Peripherals:
             self._ctp.append(cap)
 
         self.i2c = board.I2C()
-        self._dps310 = adafruit_dps310.DPS310(self.i2c)
+        self._dps310 = adafruit_dps310.advanced.DPS310(self.i2c)
         self._aht20 = adafruit_ahtx0.AHTx0(self.i2c)
 
         # LED


### PR DESCRIPTION
Fixes this after the latest DPS310 release. I assumed we want the advanced by default on the Fun House.
```py
Traceback (most recent call last):
  File "code.py", line 13, in <module>
  File "adafruit_funhouse/__init__.py", line 110, in __init__
  File "adafruit_funhouse/peripherals.py", line 86, in __init__
AttributeError: 'module' object has no attribute 'DPS310'
```
https://github.com/adafruit/Adafruit_CircuitPython_DPS310/releases/tag/2.0.0