### PR TITLE
Fixed DPS310 import for current DPS310 library

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -32,7 +32,7 @@ from digitalio import DigitalInOut, Direction, Pull
 from analogio import AnalogIn
 import touchio
 import simpleio
-import adafruit_dps310
+from adafruit_dps310.basic import DPS310
 import adafruit_ahtx0
 import adafruit_dotstar
 
@@ -83,7 +83,7 @@ class Peripherals:
             self._ctp.append(cap)
 
         self.i2c = board.I2C()
-        self._dps310 = adafruit_dps310.DPS310(self.i2c)
+        self._dps310 = DPS310(self.i2c)
         self._aht20 = adafruit_ahtx0.AHTx0(self.i2c)
 
         # LED


### PR DESCRIPTION
Noted that the current version of DPS310 has .basic and .advanced classes and was breaking funhouse init. This is the bare minimum to get it working again.