### PR TITLE
Adding documentation for `dotstars` attribute.

### DIFF
--- a/adafruit_funhouse/peripherals.py
+++ b/adafruit_funhouse/peripherals.py
@@ -46,7 +46,13 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FunHouse.git"
 
 
 class Peripherals:
-    """Peripherals Helper Class for the FunHouse Library"""
+    """Peripherals Helper Class for the FunHouse Library
+
+
+    Attributes:
+        dotstars (DotStar): The DotStars on the FunHouse board.
+            See https://circuitpython.readthedocs.io/projects/dotstar/en/latest/api.html
+    """
 
     # pylint: disable=too-many-instance-attributes, too-many-locals, too-many-branches, too-many-statements
     def __init__(self) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Adafruit-Blinka
 adafruit-blinka-displayio
 adafruit-circuitpython-portalbase
 adafruit-circuitpython-dotstar
-adafruit-circuitpython-requests
+adafruit-circuitpython-requests>=1.10.5
 adafruit-circuitpython-simpleio
 adafruit-circuitpython-minimqtt
 adafruit-circuitpython-dps310


### PR DESCRIPTION
I couldn't figure out how the API docs were generated and sent to https://circuitpython.readthedocs.io/projects/funhouse/en/latest/api.html#adafruit-funhouse-peripherals and so I've not been able to test this formats OK.

If someone could give me a pointer on how to run a test build of the API doc, I'd be happy to give it a test.